### PR TITLE
Improve wrapper width & improve width calculating in SCSS

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -244,8 +244,7 @@ th, td {
  * Wrapper
  */
 .wrapper {
-    max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit} * 2));
-    max-width:         calc(#{$content-width} - (#{$spacing-unit} * 2));
+    max-width: $content-width - $spacing-unit * 2;
     margin-right: auto;
     margin-left: auto;
     padding-right: $spacing-unit;
@@ -253,8 +252,7 @@ th, td {
     @extend %clearfix;
 
     @include media-query($on-laptop) {
-        max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit}));
-        max-width:         calc(#{$content-width} - (#{$spacing-unit}));
+        max-width: $content-width - $spacing-unit;
         padding-right: $spacing-unit / 2;
         padding-left: $spacing-unit / 2;
     }

--- a/css/style.scss
+++ b/css/style.scss
@@ -23,10 +23,10 @@ $grey-color-light: lighten($grey-color, 40%);
 $grey-color-dark:  darken($grey-color, 25%);
 
 // Width of the content area
-$content-width:    800px;
+$content-width:    825px;
 
 $on-palm:          600px;
-$on-laptop:        800px;
+$on-laptop:        825px;
 
 
 


### PR DESCRIPTION
- 已有 pre-processor 的情況下，避免使用 calc() 以強化瀏覽器支援、避開不必要的非標準功能
- 解決 wrapper 寬度過窄，導致導航條 "MIDNIGHT" 連結溢出而換行的問題